### PR TITLE
Add options "dateTimeFormats" and "numberFormats"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Installation & Configuration
   ]
 }
 ```
+The available options are:
+- **languages** (default: `[en]`): List of languages
+- **dateTimeFormats** (default: `{}`): The formats for date time
+- **numberFormats** (default: `{}`): The formats for number
 - Create files `assets/locale/en.json` and `assets/locale/de.json` with your global translation phrases.
 For example:
 ```json

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Those routes will also be generated when rendering in SSR mode.
 Installation & Configuration
 ----------------------------
 
-### Setup
-- Add `nuxt-i18n-module` dependency using yarn or npm to your project
-- Add `nuxt-i18n-module` to `modules` section of `nuxt.config.js` and define the languages to use:
+### Installation & Configuration
+1: Add `nuxt-i18n-module` dependency using yarn or npm to your project
+2: Add `nuxt-i18n-module` to `modules` section of `nuxt.config.js` and define the languages to use:
 ```js
 {
   modules: [
@@ -44,7 +44,8 @@ The available options are:
 - **languages** (default: `[en]`): List of languages
 - **dateTimeFormats** (default: `{}`): The formats for date time
 - **numberFormats** (default: `{}`): The formats for number
-- Create files `assets/locale/en.json` and `assets/locale/de.json` with your global translation phrases.
+
+3: Create files `assets/locale/en.json` and `assets/locale/de.json` with your global translation phrases.
 For example:
 ```json
 {

--- a/src/templates/plugin.js
+++ b/src/templates/plugin.js
@@ -30,6 +30,8 @@ export default ({app, store}) => {
     locale: store.state['i18n'].language,
     fallbackLocale: options.languages[0],
     messages: messages,
+    dateTimeFormats: options.dateTimeFormats || {},
+    numberFormats: options.numberFormats || {},
     silentTranslationWarn: true
   })
 


### PR DESCRIPTION
Add missings options for "vue-i18n" v7.0+

The options added : 
- **dateTimeFormats** : The formats for date time
- **numberFormats** : The formats for number

Thanks.