### PR TITLE
Don't change routes order, instead be more specific when matching `lang` param in URL

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,9 +30,6 @@ module.exports = function (moduleOptions) {
 
   // Add routes for *routing*
   this.extendRoutes(function (routes) {
-    routes.sort((a, b) => {
-      return b['path'].length - a['path'].length
-    })
     routes.forEach(route => {
       route.path = addLangParamToRoute(route.path)
     })
@@ -115,7 +112,8 @@ module.exports = function (moduleOptions) {
    * @returns {string}
    */
   function addLangParamToRoute (path) {
-    return `/:lang([\\w-]{2,5})?${path}`
+    let langs = moduleOptions.languagesExplicit.join('|')
+    return `/:lang(${langs})?${path}`
   }
 
   /**


### PR DESCRIPTION
The application might depend on the order of routes, so we shouldn't mess with it.

To avoid false positive matches of the "lang" param instead we restrict it to the available languages.