### PR TITLE
Freeze 'messages' before passing them to vue-i18n

### DIFF
--- a/src/templates/plugin.js
+++ b/src/templates/plugin.js
@@ -35,7 +35,7 @@ export default ({app, store}) => {
   app.i18n = new VueI18n({
     locale: store.state['i18n'].language,
     fallbackLocale: options.defaultLanguage,
-    messages: messages,
+    messages: Object.freeze(messages),
     dateTimeFormats: options.dateTimeFormats || {},
     numberFormats: options.numberFormats || {},
     silentTranslationWarn: true


### PR DESCRIPTION
All data passed to vue-i18n is made "reactive" using Vue, which incurs a performance overhead.
Since we assume that i18n messages don't change during runtime, we can freeze them, which avoids
them becoming reactive.

See https://stackoverflow.com/a/47452775/3090404

Here's the place where vue-i18n makes all data reactive ([ref](https://github.com/kazupon/vue-i18n/blob/4aecf0329dbb8cb0e19e0cfbfe8fb7b3e5737f8e/src/index.js#L167)):
```js
  _initVM (data: {
    locale: Locale,
    fallbackLocale: Locale,
    messages: LocaleMessages,
    dateTimeFormats: DateTimeFormats,
    numberFormats: NumberFormats
  }): void {
    const silent = Vue.config.silent
    Vue.config.silent = true
    this._vm = new Vue({ data })
[...]
```