### PR TITLE
Fix missing query string when redirect to new url.

### DIFF
--- a/src/templates/plugin.js
+++ b/src/templates/plugin.js
@@ -46,7 +46,10 @@ export default ({app, store}) => {
     redirectDefaultLang = {
       beforeMount () {
         if (!this.$options.parent && !this.$route.params.lang) {
-          this.$router.replace({params: {lang: this.i18nDetectLanguage()}})
+          this.$router.replace({
+            params: {lang: this.i18nDetectLanguage()},
+            query: { ...this.$route.query }
+          })
         }
       }
     }


### PR DESCRIPTION
When `redirectDefaultLang` is `true`, redirect to new url not pass query string.